### PR TITLE
Refactor info object

### DIFF
--- a/models/extension_test.go
+++ b/models/extension_test.go
@@ -1,86 +1,62 @@
 package models
 
 import (
+	"encoding/json"
 	"testing"
 
 	"gotest.tools/assert"
 	is "gotest.tools/assert/cmp"
 )
 
-func TestUnmarshalExtensions(t *testing.T) {
-	info := Info{}
-	result, err := UnmarshalExtensions([]byte(`{"x-test": "test value"}`))
-	info.Extensions = result
-	assert.Assert(t, is.Nil(err))
-	assert.Equal(t, len(info.Extensions), 1)
-	assert.Equal(t, info.Extensions["x-test"], "test value")
-}
-
-func TestMarshalWithExtensions(t *testing.T) {
+func TestMergeExtensions(t *testing.T) {
 	info := Info{
-		Extensions: Extensions{
-			"x-test": "test value",
-		},
 		Title:   "Test",
 		Version: "1.0.0",
 	}
-	result, err := MarshalWithExtensions(info, info.Extensions)
+	jsonByteArray, err := json.Marshal(info)
+	result, err := MergeExtensions(jsonByteArray, map[string]json.RawMessage{
+		"x-test": json.RawMessage(`"test value"`),
+	})
 	assert.Assert(t, is.Nil(err))
 	assert.Equal(t, string(result), `{"x-test":"test value","title":"Test","version":"1.0.0"}`)
 }
 
-func TestMarshalWithExtensionsOnEmptyInfo(t *testing.T) {
-	info := Info{
-		Extensions: Extensions{
-			"x-test": "test value",
-		},
-	}
-	result, err := MarshalWithExtensions(Info{}, info.Extensions)
+func TestMergeExtensionsOnEmptyInfo(t *testing.T) {
+	result, err := MergeExtensions([]byte(""), map[string]json.RawMessage{
+		"x-test": json.RawMessage(`"test value"`),
+	})
 	assert.Assert(t, is.Nil(err))
 	assert.Equal(t, string(result), `{"x-test":"test value"}`)
 }
 
-func TestMarshalWithExtensionsOnNilInfo(t *testing.T) {
-	info := Info{
-		Extensions: Extensions{
-			"x-test": "test value",
-		},
-	}
-	result, err := MarshalWithExtensions(nil, info.Extensions)
-	assert.Equal(t, err.Error(), `Object can't be nil.`)
+func TestMergeExtensionsOnNilInfo(t *testing.T) {
+	result, err := MergeExtensions(nil, map[string]json.RawMessage{
+		"x-test": json.RawMessage(`"test value"`),
+	})
+	assert.Equal(t, err.Error(), `jsonByteArray can't be nil`)
 	assert.Assert(t, is.Nil(result))
 }
 
-func TestMarshalWithExtensionsOnEmptyExtensions(t *testing.T) {
-	info := Info{
-		Extensions: Extensions{},
-		Title:      "Test",
-	}
-	result, err := MarshalWithExtensions(info, info.Extensions)
+func TestMergeExtensionsOnEmptyExtensions(t *testing.T) {
+	result, err := MergeExtensions([]byte(`{"title":"Test"}`), map[string]json.RawMessage{})
 	assert.Assert(t, is.Nil(err))
 	assert.Equal(t, string(result), `{"title":"Test"}`)
 }
 
-func TestMarshalWithExtensionsOnNilExtensions(t *testing.T) {
-	info := Info{
-		Title: "Test",
-	}
-	result, err := MarshalWithExtensions(info, nil)
-	assert.Equal(t, err.Error(), `Extensions can't be nil.`)
-	assert.Assert(t, is.Nil(result))
+func TestMergeExtensionsOnNilExtensions(t *testing.T) {
+	result, err := MergeExtensions([]byte(`{"title":"Test"}`), nil)
+	assert.Assert(t, is.Nil(err))
+	assert.Equal(t, string(result), `{"title":"Test"}`)
 }
 
-func TestMarshalWithExtensionsOnEmptyValues(t *testing.T) {
-	info := Info{
-		Extensions: Extensions{},
-	}
-	result, err := MarshalWithExtensions(Info{}, info.Extensions)
+func TestMergeExtensionsOnEmptyValues(t *testing.T) {
+	result, err := MergeExtensions([]byte(""), map[string]json.RawMessage{})
 	assert.Assert(t, is.Nil(err))
 	assert.Equal(t, string(result), `{}`)
 }
 
-func TestMarshalWithExtensionsOnNilValues(t *testing.T) {
-	result, err := MarshalWithExtensions(nil, nil)
-	assert.Equal(t, err.Error(), `Extensions can't be nil.`)
+func TestMergeExtensionsOnNilValues(t *testing.T) {
+	result, err := MergeExtensions(nil, nil)
+	assert.Equal(t, err.Error(), `jsonByteArray can't be nil`)
 	assert.Assert(t, is.Nil(result))
 }

--- a/models/extension_test.go
+++ b/models/extension_test.go
@@ -8,6 +8,40 @@ import (
 	is "gotest.tools/assert/cmp"
 )
 
+func TestExtensionsFromJSON(t *testing.T) {
+	result, err := ExtensionsFromJSON([]byte(`{
+		"not-extension": "should not be included",
+		"x-test": "test value"
+	}`))
+	assert.Assert(t, is.Nil(err))
+	assert.Assert(t, is.Nil(result["not-extension"]))
+	assert.Equal(t, string(result["x-test"]), `"test value"`)
+}
+
+func TestExtensionsFromJSONWithObject(t *testing.T) {
+	result, err := ExtensionsFromJSON([]byte(`{
+		"x-test": {"one": {"two": 2}}
+	}`))
+	assert.Assert(t, is.Nil(err))
+	assert.Equal(t, string(result["x-test"]), `{"one": {"two": 2}}`)
+}
+
+func TestExtensionsFromJSONWithArray(t *testing.T) {
+	result, err := ExtensionsFromJSON([]byte(`{
+		"x-test": [1, "one", true]
+	}`))
+	assert.Assert(t, is.Nil(err))
+	assert.Equal(t, string(result["x-test"]), `[1, "one", true]`)
+}
+
+func TestExtensionsFromJSONWithNull(t *testing.T) {
+	result, err := ExtensionsFromJSON([]byte(`{
+		"x-test": null
+	}`))
+	assert.Assert(t, is.Nil(err))
+	assert.Equal(t, string(result["x-test"]), `null`)
+}
+
 func TestMergeExtensions(t *testing.T) {
 	info := Info{
 		Title:   "Test",

--- a/models/info.go
+++ b/models/info.go
@@ -6,59 +6,135 @@ import (
 
 // Info maps AsyncAPI info object
 type Info struct {
-	Extensions     Extensions `json:"-"`
-	Title          string     `json:"title,omitempty"`
-	Description    string     `json:"description,omitempty"`
-	TermsOfService string     `json:"termsOfService,omitempty"`
-	Contact        *Contact   `json:"contact,omitempty"`
-	License        *License   `json:"license,omitempty"`
-	Version        string     `json:"version,omitempty"`
+	Extensions     map[string]json.RawMessage `json:"-"`
+	Title          string                     `json:"title,omitempty"`
+	Description    string                     `json:"description,omitempty"`
+	TermsOfService string                     `json:"termsOfService,omitempty"`
+	Contact        *Contact                   `json:"contact,omitempty"`
+	License        *License                   `json:"license,omitempty"`
+	Version        string                     `json:"version,omitempty"`
 }
 
-// Unmarshal unmarshals JSON
-func (value *Info) Unmarshal(data []byte) error {
-	return json.Unmarshal(data, value)
-}
-
-// Marshal marshals JSON
-func (value *Info) Marshal() ([]byte, error) {
-	if value.Extensions == nil {
-		return json.Marshal(value)
+// UnmarshalJSON unmarshals JSON
+func (value *Info) UnmarshalJSON(data []byte) error {
+	type Alias Info
+	jsonMap := Alias{}
+	var err error
+	if err = json.Unmarshal(data, &jsonMap); err != nil {
+		return err
 	}
-	return MarshalWithExtensions(value, value.Extensions)
+
+	value.Title = jsonMap.Title
+	value.Description = jsonMap.Description
+	value.TermsOfService = jsonMap.TermsOfService
+	value.Contact = jsonMap.Contact
+	value.License = jsonMap.License
+	value.Version = jsonMap.Version
+	exts, err := ExtensionsFromJSON(data)
+	if err != nil {
+		return err
+	}
+	value.Extensions = exts
+	return nil
+}
+
+// MarshalJSON marshals JSON
+func (value Info) MarshalJSON() ([]byte, error) {
+	type Alias Info
+	jsonByteArray, err := json.Marshal(&Alias{
+		Title:          value.Title,
+		Description:    value.Description,
+		TermsOfService: value.TermsOfService,
+		Contact:        value.Contact,
+		License:        value.License,
+		Version:        value.Version,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return MergeExtensions(jsonByteArray, value.Extensions)
 }
 
 // Contact maps AsyncAPI info.contact object
 type Contact struct {
-	Extensions *Extensions `json:"-"`
-	Name       string      `json:"name,omitempty"`
-	URL        string      `json:"url,omitempty"`
-	Email      string      `json:"email,omitempty"`
+	Extensions map[string]json.RawMessage `json:"-"`
+	Name       string                     `json:"name,omitempty"`
+	URL        string                     `json:"url,omitempty"`
+	Email      string                     `json:"email,omitempty"`
 }
 
-// Unmarshal unmarshals JSON
-func (value *Contact) Unmarshal(data []byte) error {
-	return json.Unmarshal(data, value)
+// UnmarshalJSON unmarshals JSON
+func (value *Contact) UnmarshalJSON(data []byte) error {
+	type Alias Contact
+	jsonMap := Alias{}
+	var err error
+	if err = json.Unmarshal(data, &jsonMap); err != nil {
+		return err
+	}
+
+	value.Name = jsonMap.Name
+	value.URL = jsonMap.URL
+	value.Email = jsonMap.Email
+	exts, err := ExtensionsFromJSON(data)
+	if err != nil {
+		return err
+	}
+	value.Extensions = exts
+	return nil
 }
 
-// Marshal marshals JSON
-func (value *Contact) Marshal() ([]byte, error) {
-	return json.Marshal(value)
+// MarshalJSON marshals JSON
+func (value *Contact) MarshalJSON() ([]byte, error) {
+	type Alias Contact
+	jsonByteArray, err := json.Marshal(&Alias{
+		Name:  value.Name,
+		URL:   value.URL,
+		Email: value.Email,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return MergeExtensions(jsonByteArray, value.Extensions)
 }
 
 // License maps AsyncAPI info.license object
 type License struct {
-	Extensions *Extensions `json:"-"`
-	Name       string      `json:"name,omitempty"`
-	URL        string      `json:"url,omitempty"`
+	Extensions map[string]json.RawMessage `json:"-"`
+	Name       string                     `json:"name,omitempty"`
+	URL        string                     `json:"url,omitempty"`
 }
 
-// Unmarshal unmarshals JSON
-func (value *License) Unmarshal(data []byte) error {
-	return json.Unmarshal(data, value)
+// UnmarshalJSON unmarshals JSON
+func (value *License) UnmarshalJSON(data []byte) error {
+	type Alias License
+	jsonMap := Alias{}
+	var err error
+	if err = json.Unmarshal(data, &jsonMap); err != nil {
+		return err
+	}
+
+	value.Name = jsonMap.Name
+	value.URL = jsonMap.URL
+	exts, err := ExtensionsFromJSON(data)
+	if err != nil {
+		return err
+	}
+	value.Extensions = exts
+	return nil
 }
 
-// Marshal marshals JSON
-func (value *License) Marshal() ([]byte, error) {
-	return json.Marshal(value)
+// MarshalJSON marshals JSON
+func (value *License) MarshalJSON() ([]byte, error) {
+	type Alias License
+	jsonByteArray, err := json.Marshal(&Alias{
+		Name: value.Name,
+		URL:  value.URL,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return MergeExtensions(jsonByteArray, value.Extensions)
 }


### PR DESCRIPTION
### What?
Refactors how we marshal and unmarshal JSON in the Info object. The idea is to repeat this pattern for every model.

### Why?
We can now leverage the `json.Unmarshal` and `json.Marshal` methods, making it easier to marshal and unmarshal deep objects.