### PR TITLE
Add tests to OperationMessage and SecurityScheme

### DIFF
--- a/models/models_test.go
+++ b/models/models_test.go
@@ -2,32 +2,11 @@ package models
 
 import (
 	"encoding/json"
-	"io/ioutil"
-	"os"
 	"testing"
 
 	"gotest.tools/assert"
 	is "gotest.tools/assert/cmp"
 )
-
-func TestA(t *testing.T) {
-	jsonFile, err := os.Open("../asyncapi/2.0.0/example.json")
-	if err != nil {
-		t.Log(err)
-	}
-	defer jsonFile.Close()
-
-	byteValue, _ := ioutil.ReadAll(jsonFile)
-	var AsyncAPI AsyncapiDocument
-	err = json.Unmarshal(byteValue, &AsyncAPI)
-	if err != nil {
-		t.Log(err)
-	}
-	t.Log(AsyncAPI.Channels["event/{streetlightId}/lighting/measured"].Subscribe.Message.Payload)
-
-	// j, err := json.Marshal(AsyncAPI.Channels)
-	// t.Log(string(j))
-}
 
 func TestInfoUnmarshal(t *testing.T) {
 	info := Info{}

--- a/models/operation-message.go
+++ b/models/operation-message.go
@@ -29,6 +29,20 @@ func (value *OperationMessage) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	value.SchemaFormat = jsonMap.SchemaFormat
+	value.ContentType = jsonMap.ContentType
+	value.Headers = jsonMap.Headers
+	value.Payload = jsonMap.Payload
+	value.Tags = jsonMap.Tags
+	value.Summary = jsonMap.Summary
+	value.Name = jsonMap.Name
+	value.Title = jsonMap.Title
+	value.Description = jsonMap.Description
+	value.ExternalDocs = jsonMap.ExternalDocs
+	value.Deprecated = jsonMap.Deprecated
+	value.Example = jsonMap.Example
+	value.OneOf = jsonMap.OneOf
+
 	exts, err := ExtensionsFromJSON(data)
 	if err != nil {
 		return err

--- a/models/operation-message_test.go
+++ b/models/operation-message_test.go
@@ -1,0 +1,73 @@
+package models
+
+import (
+	"encoding/json"
+	"testing"
+
+	"gotest.tools/assert"
+	is "gotest.tools/assert/cmp"
+)
+
+func TestOperationMessageUnmarshal(t *testing.T) {
+	om := OperationMessage{}
+	err := json.Unmarshal([]byte(`{
+		"x-test": {"nested": "object"},
+		"name": "lightMeasured",
+		"title": "Light measured",
+		"summary": "Inform about environmental lighting conditions for a particular streetlight.",
+		"contentType": "application/json",
+		"payload": {
+			"type": "object",
+			"properties": {
+				"lumens": {
+					"type": "integer",
+					"minimum": 0,
+					"description": "Light intensity measured in lumens."
+				},
+				"sentAt": {
+					"type": "string",
+					"format": "date-time",
+					"description": "Date and time when the message was sent."
+				}
+			}
+		}
+	}`), &om)
+	assert.Assert(t, is.Nil(err))
+	assert.Equal(t, om.Name, "lightMeasured")
+	assert.Equal(t, om.Title, "Light measured")
+	assert.Equal(t, om.Summary, "Inform about environmental lighting conditions for a particular streetlight.")
+	assert.Equal(t, om.ContentType, "application/json")
+	assert.Equal(t, string(om.Payload), string(json.RawMessage(`{
+			"type": "object",
+			"properties": {
+				"lumens": {
+					"type": "integer",
+					"minimum": 0,
+					"description": "Light intensity measured in lumens."
+				},
+				"sentAt": {
+					"type": "string",
+					"format": "date-time",
+					"description": "Date and time when the message was sent."
+				}
+			}
+		}`)))
+	assert.Equal(t, string(om.Extensions["x-test"]), `{"nested": "object"}`)
+	assert.Assert(t, is.Nil(om.Extensions["invalid"]))
+}
+
+func TestOperationMessageMarshal(t *testing.T) {
+	om := OperationMessage{
+		Extensions: map[string]json.RawMessage{
+			"x-test": json.RawMessage(`"test value"`),
+		},
+		Title:       "Light measured",
+		Name:        "lightMeasured",
+		Summary:     "Inform about environmental lighting conditions for a particular streetlight.",
+		ContentType: "application/json",
+		Payload:     json.RawMessage("{}"),
+	}
+	result, err := json.Marshal(om)
+	assert.Assert(t, is.Nil(err))
+	assert.Equal(t, string(result), `{"x-test":"test value","contentType":"application/json","payload":{},"summary":"Inform about environmental lighting conditions for a particular streetlight.","name":"lightMeasured","title":"Light measured"}`)
+}

--- a/models/security-scheme.go
+++ b/models/security-scheme.go
@@ -21,6 +21,12 @@ func (value *SecurityScheme) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	value.Type = jsonMap.Type
+	value.Description = jsonMap.Description
+	value.In = jsonMap.In
+	value.Flows = jsonMap.Flows
+	value.OpenIdConnectUrl = jsonMap.OpenIdConnectUrl
+
 	exts, err := ExtensionsFromJSON(data)
 	if err != nil {
 		return err
@@ -65,6 +71,13 @@ func (value *HttpSecurityScheme) UnmarshalJSON(data []byte) error {
 	if err = json.Unmarshal(data, &jsonMap); err != nil {
 		return err
 	}
+
+	value.Scheme = jsonMap.Scheme
+	value.Description = jsonMap.Description
+	value.Type = jsonMap.Type
+	value.BearerFormat = jsonMap.BearerFormat
+	value.Name = jsonMap.Name
+	value.In = jsonMap.In
 
 	exts, err := ExtensionsFromJSON(data)
 	if err != nil {

--- a/models/security-scheme_test.go
+++ b/models/security-scheme_test.go
@@ -1,0 +1,149 @@
+package models
+
+import (
+	"encoding/json"
+	"testing"
+
+	"gotest.tools/assert"
+	is "gotest.tools/assert/cmp"
+)
+
+func TestSecuritySchemeUnmarshal(t *testing.T) {
+	ss := SecurityScheme{}
+	err := json.Unmarshal([]byte(`{
+		"x-test": {"nested": "object"},
+		"type": "oauth2",
+		"description": "Flows to support OAuth 2.0",
+		"flows": {
+			"implicit": {
+				"authorizationUrl": "https://authserver.example/auth",
+				"scopes": {
+					"streetlights:on": "Ability to switch lights on",
+					"streetlights:off": "Ability to switch lights off",
+					"streetlights:dim": "Ability to dim the lights"
+				}
+			},
+			"password": {
+				"tokenUrl": "https://authserver.example/token",
+				"scopes": {
+					"streetlights:on": "Ability to switch lights on",
+					"streetlights:off": "Ability to switch lights off",
+					"streetlights:dim": "Ability to dim the lights"
+				}
+			},
+			"clientCredentials": {
+				"tokenUrl": "https://authserver.example/token",
+				"scopes": {
+					"streetlights:on": "Ability to switch lights on",
+					"streetlights:off": "Ability to switch lights off",
+					"streetlights:dim": "Ability to dim the lights"
+				}
+			},
+			"authorizationCode": {
+				"authorizationUrl": "https://authserver.example/auth",
+				"tokenUrl": "https://authserver.example/token",
+				"refreshUrl": "https://authserver.example/refresh",
+				"scopes": {
+					"streetlights:on": "Ability to switch lights on",
+					"streetlights:off": "Ability to switch lights off",
+					"streetlights:dim": "Ability to dim the lights"
+				}
+			}
+		}
+	}`), &ss)
+	assert.Assert(t, is.Nil(err))
+	assert.Equal(t, ss.Type, "oauth2")
+	assert.Equal(t, ss.Description, "Flows to support OAuth 2.0")
+	assert.Equal(t, string(ss.Flows), string(json.RawMessage(`{
+			"implicit": {
+				"authorizationUrl": "https://authserver.example/auth",
+				"scopes": {
+					"streetlights:on": "Ability to switch lights on",
+					"streetlights:off": "Ability to switch lights off",
+					"streetlights:dim": "Ability to dim the lights"
+				}
+			},
+			"password": {
+				"tokenUrl": "https://authserver.example/token",
+				"scopes": {
+					"streetlights:on": "Ability to switch lights on",
+					"streetlights:off": "Ability to switch lights off",
+					"streetlights:dim": "Ability to dim the lights"
+				}
+			},
+			"clientCredentials": {
+				"tokenUrl": "https://authserver.example/token",
+				"scopes": {
+					"streetlights:on": "Ability to switch lights on",
+					"streetlights:off": "Ability to switch lights off",
+					"streetlights:dim": "Ability to dim the lights"
+				}
+			},
+			"authorizationCode": {
+				"authorizationUrl": "https://authserver.example/auth",
+				"tokenUrl": "https://authserver.example/token",
+				"refreshUrl": "https://authserver.example/refresh",
+				"scopes": {
+					"streetlights:on": "Ability to switch lights on",
+					"streetlights:off": "Ability to switch lights off",
+					"streetlights:dim": "Ability to dim the lights"
+				}
+			}
+		}`)))
+	assert.Equal(t, string(ss.Extensions["x-test"]), `{"nested": "object"}`)
+	assert.Assert(t, is.Nil(ss.Extensions["invalid"]))
+}
+
+func TestSecuritySchemeMarshal(t *testing.T) {
+	ss := SecurityScheme{
+		Extensions: map[string]json.RawMessage{
+			"x-test": json.RawMessage(`"test value"`),
+		},
+		Type:        "oauth2",
+		Description: "Flows to support OAuth 2.0",
+		Flows:       json.RawMessage("{}"),
+		In:          "header",
+	}
+	result, err := json.Marshal(ss)
+	assert.Assert(t, is.Nil(err))
+	assert.Equal(t, string(result), `{"x-test":"test value","type":"oauth2","description":"Flows to support OAuth 2.0","in":"header","flows":{}}`)
+}
+
+func TestHttpSecuritySchemeUnmarshal(t *testing.T) {
+	hss := HttpSecurityScheme{}
+	err := json.Unmarshal([]byte(`{
+		"x-test": {"nested": "object"},
+		"scheme": "a",
+		"description": "b",
+		"type": "c",
+		"bearerFormat": "d",
+		"name": "e",
+		"in": "f"
+	}`), &hss)
+	assert.Assert(t, is.Nil(err))
+	assert.Equal(t, hss.Scheme, "a")
+	assert.Equal(t, hss.Description, "b")
+	assert.Equal(t, hss.Type, "c")
+	assert.Equal(t, hss.BearerFormat, "d")
+	assert.Equal(t, hss.Name, "e")
+	assert.Equal(t, hss.In, "f")
+	assert.Equal(t, string(hss.Extensions["x-test"]), `{"nested": "object"}`)
+	assert.Assert(t, is.Nil(hss.Extensions["invalid"]))
+}
+
+func TestHttpSecuritySchemeMarshal(t *testing.T) {
+	ss := HttpSecurityScheme{
+		Extensions: map[string]json.RawMessage{
+			"x-test": json.RawMessage(`"test value"`),
+		},
+		Scheme:       "a",
+		Description:  "b",
+		Type:         "c",
+		BearerFormat: "d",
+		Name:         "e",
+		In:           "f",
+	}
+	result, err := json.Marshal(ss)
+	assert.Assert(t, is.Nil(err))
+	assert.Equal(t, string(result), `{"x-test":"test value","scheme":"a","description":"b","type":"c","bearerFormat":"d","name":"e","in":"f"}`)
+}


### PR DESCRIPTION
### What?
It adds basic unit tests to OperationMessage and SecurityScheme structs.

### Why?
They were missing on my last PR.