### PR TITLE
Move main code to cmd

### DIFF
--- a/cmd/tester/main.go
+++ b/cmd/tester/main.go
@@ -1,4 +1,4 @@
-package main
+package tester
 
 import (
 	"encoding/json"

--- a/cparser/cparser.go
+++ b/cparser/cparser.go
@@ -1,4 +1,4 @@
-package cparser
+package main
 
 // typedef struct {
 //  char *result;


### PR DESCRIPTION
### What?
I'm moving the code in `main.go` to `cmd/tester/main.go` and putting the `cparser` package back to `main`.

### Why?
For two reasons:
1. I want to compile to C in multiple platforms. For that purpose, we need to have exactly one `main` package, otherwise, it will not compile.
2. This package is meant to just contain a library. If we want to create a CLI tool, we should create another package that uses this one as a dependency. Why is that? Because we're going to use this library as a dependency in many places so the smaller it is the better.