### PR TITLE
Deref improv

### DIFF
--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -14,6 +14,7 @@ import (
 var (
 	defaultDefinitionFile = "asyncapi/2.0.0/example.yaml"
 	filename              = flag.String("file", defaultDefinitionFile, fmt.Sprintf("-file %s", defaultDefinitionFile))
+	circularReferences    = flag.Bool("c", true, "-c=[true,false]")
 )
 
 func init() {
@@ -23,7 +24,7 @@ func init() {
 func main() {
 	fBytes, err := ioutil.ReadFile(*filename)
 	handleError(err, "Reading file")
-	p, perr := parser.Parse(fBytes)
+	p, perr := parser.Parse(fBytes, *circularReferences)
 	if perr != nil {
 		fmt.Fprintln(os.Stderr, errors.Wrap(perr, perr.Error()))
 		fmt.Fprintln(os.Stderr, perr.ParsingErrors)

--- a/cparser/cparser.go
+++ b/cparser/cparser.go
@@ -16,8 +16,8 @@ import (
 
 //Parse is the C-friendly version of the parser.Parse method.
 //export Parse
-func Parse(yamlOrJSONDocument string) C._ParseResult_ {
-	jsonDoc, err := hlsp.ParseForC([]byte(yamlOrJSONDocument))
+func Parse(yamlOrJSONDocument string, circularReferences bool) C._ParseResult_ {
+	jsonDoc, err := hlsp.ParseForC([]byte(yamlOrJSONDocument), circularReferences)
 
 	if err != nil {
 		ea, count := makeCErrorArray(err)

--- a/pkg/dereferencer/filedereferencer_test.go
+++ b/pkg/dereferencer/filedereferencer_test.go
@@ -36,12 +36,147 @@ components:
 	externalContent = `{"components":{"parameters":{"streetlightId":{"description":"The ID of the streetlight.","name":"streetlightId","schema":null,"type":"string"}}}}`
 
 	expectedResolved = `[{"description":"The ID of the streetlight.","name":"streetlightId","schema":null,"type":"string"}]`
+
+	circularRef = `definitions:
+  child:
+    title: child
+    type: object
+    properties:
+      name:
+        type: string
+      pet:
+        $ref: '#/definitions/pet'
+
+  thing:
+    $ref: "#/definitions/thing"         # <--- circular reference to self
+
+  pet:
+    title: pet
+    type: object
+    properties:
+      name:
+        type: string
+      age:
+        type: number
+      species:
+        type: string
+        enum:
+          - cat
+          - dog
+          - bird
+          - fish`
+
+	indirectCircularRef = `definitions:
+    parent:
+      title: parent
+      properties:
+        name:
+          type: string
+        children:
+          type: array
+          items:
+            $ref: "#/definitions/child"       # <--- indirect circular reference
+  
+    child:
+      title: child
+      properties:
+        name:
+          type: string
+        pet:
+          $ref: '#/definitions/pet'
+        parents:
+          type: array
+          items:
+            $ref: "#/definitions/parent"      # <--- indirect circular reference
+  
+    pet:
+      title: pet
+      type: object
+      properties:
+        name:
+          type: string
+        age:
+          type: number
+        species:
+          type: string
+          enum:
+            - cat
+            - dog
+            - bird
+            - fish`
+
+	ancestorCircularRef = `definitions:
+  person:
+    title: person
+    properties:
+      name:
+        type: string
+      pet:
+        $ref: '#/definitions/pet'
+      spouse:
+        $ref: "#/definitions/person"       # <--- circular reference to ancestor
+      age:
+        type: number
+
+  pet:
+    title: pet
+    type: object
+    properties:
+      name:
+        type: string
+      age:
+        type: number
+      species:
+        type: string
+        enum:
+          - cat
+          - dog
+          - bird
+          - fish`
+	indirectAncestorCircularRef = `definitions:
+  parent:
+    title: parent
+    properties:
+      name:
+        type: string
+      child:
+        $ref: '#/definitions/child'           # <--- indirect circular reference
+
+  child:
+    title: child
+    properties:
+      name:
+        type: string
+      pet:
+        $ref: '#/definitions/pet'
+      children:
+        description: children
+        type: array
+        items:
+          $ref: '#/definitions/child'         # <--- circular reference to ancestor
+
+  pet:
+    title: pet
+    type: object
+    properties:
+      name:
+        type: string
+      age:
+        type: number
+      species:
+        type: string
+        enum:
+          - cat
+          - dog
+          - bird
+          - fish`
+	circularString = `{"circular": "circular"}`
 )
 
 func TestDereferenceInFile(t *testing.T) {
 	jsonDocument, err := yaml.YAMLToJSON([]byte(refInFile))
 	assert.NoError(t, err, "error converting yaml to json")
-	resolvedDoc, err := Dereference(jsonDocument)
+	resolvedDoc, err := Dereference(jsonDocument, true)
 	assert.NoError(t, err, "error Dereferencing")
 	assert.Contains(t, string(resolvedDoc), expectedResolved, "does not contain resolved $ref")
 }
@@ -58,7 +193,28 @@ func TestDereferenceExternalFile(t *testing.T) {
 	}()
 	jsonDocument, err := yaml.YAMLToJSON([]byte(fmt.Sprintf(refExternalFile, ".")))
 	assert.NoError(t, err, "error converting yaml to json")
-	resolvedDoc, err := Dereference(jsonDocument)
+	resolvedDoc, err := Dereference(jsonDocument, true)
 	assert.NoError(t, err, "error Dereferencing")
 	assert.Contains(t, string(resolvedDoc), expectedResolved, "does not contain resolved $ref")
+}
+
+func TestCircularDereferencesInFile(t *testing.T) {
+	circularReferences := []string{circularRef, indirectCircularRef, ancestorCircularRef, indirectAncestorCircularRef}
+	for i := 0; i < len(circularReferences); i++ {
+		jsonDocument, err := yaml.YAMLToJSON([]byte(circularReferences[i]))
+		assert.NoError(t, err, "error converting yaml to json")
+		resolvedDoc, err := Dereference(jsonDocument, true)
+		assert.NoError(t, err, "error Dereferencing")
+		assert.Contains(t, string(resolvedDoc), circularString, "does not contain circular String in circular $ref")
+	}
+}
+
+func TestCircularDereferencesInFileFails(t *testing.T) {
+	circularReferences := []string{circularRef, indirectCircularRef, ancestorCircularRef, indirectAncestorCircularRef}
+	for i := 0; i < len(circularReferences); i++ {
+		jsonDocument, err := yaml.YAMLToJSON([]byte(circularReferences[i]))
+		assert.NoError(t, err, "error converting yaml to json")
+		_, err = Dereference(jsonDocument, false)
+		assert.Error(t, err, "Circulare reference not detected")
+	}
 }

--- a/pkg/dereferencer/httpdeferencer_test.go
+++ b/pkg/dereferencer/httpdeferencer_test.go
@@ -31,7 +31,7 @@ func TestDereferenceHttp(t *testing.T) {
 	defer ts.Close()
 	jsonDocument, err := yaml.YAMLToJSON([]byte(fmt.Sprintf(refHTTPFile, ts.URL)))
 	assert.NoError(t, err, "error converting yaml to json")
-	resolvedDoc, err := Dereference(jsonDocument)
+	resolvedDoc, err := Dereference(jsonDocument, true)
 	assert.NoError(t, err, "error Dereferencing")
 	assert.Contains(t, string(resolvedDoc), expectedResolved, "does not contain resolved $ref")
 }

--- a/pkg/hlsp/hlsp_test.go
+++ b/pkg/hlsp/hlsp_test.go
@@ -16,7 +16,7 @@ info:
   version: '1.0.0'
 channels: {}`)
 
-	doc, err := Parse(asyncapi)
+	doc, err := Parse(asyncapi, true)
 	assert.Assert(t, is.Nil(err))
 	assert.Equal(t, doc.Asyncapi, "2.0.0-rc1")
 	assert.Equal(t, doc.Id, "urn:myapi")
@@ -24,7 +24,7 @@ channels: {}`)
 func TestParseWithEmptyYAML(t *testing.T) {
 	asyncapi := []byte(``)
 
-	_, err := Parse(asyncapi)
+	_, err := Parse(asyncapi, true)
 	assert.Equal(t, err.Error(), "[Invalid AsyncAPI document] Document is empty or null.")
 	assert.Equal(t, len(err.ParsingErrors), 0)
 }
@@ -36,7 +36,7 @@ info:
   version: '1.0.0'
 channels: {}`)
 
-	_, err := Parse(asyncapi)
+	_, err := Parse(asyncapi, true)
 	assert.Equal(t, err.Error(), "[Invalid AsyncAPI document] Check out err.ParsingErrors() for more information.")
 	assert.Equal(t, len(err.ParsingErrors), 1)
 	assert.Equal(t, err.ParsingErrors[0].Details()["property"], "id")
@@ -53,7 +53,7 @@ func TestParseJSON(t *testing.T) {
 		"channels": {}
 	}`)
 
-	jsonDocument, err := ParseJSON(asyncapi)
+	jsonDocument, err := ParseJSON(asyncapi, true)
 	assert.Assert(t, is.Nil(err))
 	assert.Equal(t, string(jsonDocument), `{
 		"asyncapi": "2.0.0-rc1",
@@ -69,7 +69,7 @@ func TestParseJSON(t *testing.T) {
 func TestParseJSONWithInvalidJSON(t *testing.T) {
 	asyncapi := []byte(`"`)
 
-	jsonDocument, err := ParseJSON(asyncapi)
+	jsonDocument, err := ParseJSON(asyncapi, true)
 	assert.Equal(t, err.Error(), "unexpected EOF")
 	assert.Equal(t, len(err.ParsingErrors), 0)
 	assert.Equal(t, string(jsonDocument), ``)
@@ -78,7 +78,7 @@ func TestParseJSONWithInvalidJSON(t *testing.T) {
 func TestParseJSONWithEmptyJSON(t *testing.T) {
 	asyncapi := []byte(``)
 
-	jsonDocument, err := ParseJSON(asyncapi)
+	jsonDocument, err := ParseJSON(asyncapi, true)
 	assert.Equal(t, err.Error(), "EOF")
 	assert.Equal(t, len(err.ParsingErrors), 0)
 	assert.Equal(t, string(jsonDocument), ``)
@@ -94,7 +94,7 @@ func TestParseJSONWithInvalidDocument(t *testing.T) {
 		"channels": {}
 	}`)
 
-	jsonDocument, err := ParseJSON(asyncapi)
+	jsonDocument, err := ParseJSON(asyncapi, true)
 	assert.Equal(t, err.Error(), "[Invalid AsyncAPI document] Check out err.ParsingErrors() for more information.")
 	assert.Equal(t, len(err.ParsingErrors), 1)
 	assert.Equal(t, err.ParsingErrors[0].Details()["property"], "id")

--- a/pkg/parser.go
+++ b/pkg/parser.go
@@ -9,8 +9,8 @@ import (
 )
 
 // Parse receives either a YAML or JSON AsyncAPI document, and tries to parse it.
-func Parse(yamlOrJSONDocument []byte) (json.RawMessage, *errs.ParserError) {
-	doc, err := hlsp.Parse(yamlOrJSONDocument)
+func Parse(yamlOrJSONDocument []byte, circularReferences bool) (json.RawMessage, *errs.ParserError) {
+	doc, err := hlsp.Parse(yamlOrJSONDocument, circularReferences)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/parser_test.go
+++ b/pkg/parser_test.go
@@ -26,7 +26,7 @@ channels:
               type: string
 `)
 
-	doc, err := Parse(asyncapi)
+	doc, err := Parse(asyncapi, true)
 	assert.Assert(t, is.Nil(err))
 	fmt.Printf("ParsedFile %v", string(doc))
 	// assert.Equal(t, doc.Asyncapi, "2.0.0")

--- a/pkg/schemaparser/schemaparser_test.go
+++ b/pkg/schemaparser/schemaparser_test.go
@@ -81,7 +81,7 @@ func TestParse(t *testing.T) {
 		}
 	}`)
 
-	doc, err := hlsp.Parse(asyncapi)
+	doc, err := hlsp.Parse(asyncapi, true)
 	assert.Assert(t, is.Nil(err))
 
 	err = Parse(doc)


### PR DESCRIPTION
- Add circular reference option to cli.
- Resolve circular references either by crashing or by replacing by a object with key and value equals to circular string.
- Resolve circular references is set to true by default but you can set it to false and you'll get an error saying where you have the circular reference.